### PR TITLE
Show presence status for 1:1 chats

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/adapter/ConversationAdapter.java
+++ b/src/main/java/eu/siacs/conversations/ui/adapter/ConversationAdapter.java
@@ -143,6 +143,28 @@ public class ConversationAdapter extends ArrayAdapter<Conversation> {
 		mTimestamp.setText(UIHelper.readableTimeDifference(activity,conversation.getLatestMessage().getTimeSent()));
 		ImageView profilePicture = (ImageView) view.findViewById(R.id.conversation_image);
 		loadAvatar(conversation,profilePicture);
+		
+		View contact_status = view.findViewById(R.id.contact_status);
+        	if (conversation.getMode() == Conversation.MODE_SINGLE) {
+            		contact_status.setVisibility(View.VISIBLE);
+            		switch (conversation.getContact().getPresences().getShownStatus()) {
+                		case AWAY:
+				    contact_status.setBackgroundColor(0xffff9800);
+				    break;
+				case XA:
+				case DND:
+				    contact_status.setBackgroundColor(0xfff44336);
+				    break;
+				case OFFLINE:
+				    contact_status.setBackgroundColor(0xffc62828);
+				    break;
+				default:
+				    contact_status.setBackgroundColor(0xff259b24);
+				    break;
+			    }
+		} else {
+			contact_status.setVisibility(View.GONE);
+		}
 
 		return view;
 	}

--- a/src/main/res/layout/conversation_list_row.xml
+++ b/src/main/res/layout/conversation_list_row.xml
@@ -28,7 +28,14 @@
                 android:layout_height="56dp"
                 android:layout_alignParentLeft="true"
                 android:scaleType="centerCrop"
-                app:riv_corner_radius="2dp"/>
+                app:riv_corner_radius_bottom_right="2dp"
+                app:riv_corner_radius_top_right="2dp"/>
+
+            <View
+                android:id="@+id/contact_status"
+                android:layout_width="3dp"
+                android:layout_height="56dp"
+                android:layout_alignParentLeft="true"/>
 
             <RelativeLayout
                 android:layout_width="fill_parent"


### PR DESCRIPTION
Inspired By #589 
Adds a small presence status bar next to the Contact picture.

![screenshot](https://cloud.githubusercontent.com/assets/26378601/23850100/4f9d7f4c-07de-11e7-80c3-49c321959e65.png)
