### PR TITLE
Rework clean cache and clean private storage

### DIFF
--- a/src/main/java/eu/siacs/conversations/persistance/FileBackend.java
+++ b/src/main/java/eu/siacs/conversations/persistance/FileBackend.java
@@ -46,6 +46,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -156,6 +157,45 @@ public class FileBackend {
 
     public static String getBackupDirectory(String app) {
         return Environment.getExternalStorageDirectory().getAbsolutePath() + "/"+app+"/Backup/";
+    }
+
+    public static boolean deleteDir(File dir) {
+        if (dir != null && dir.isDirectory()) {
+            String[] children = dir.list();
+            for (int i = 0; i < children.length; i++) {
+                boolean success = deleteDir(new File(dir, children[i]));
+                if (!success) {
+                    return false;
+                }
+            }
+            return dir.delete();
+        } else if(dir!= null && dir.isFile()) {
+            return dir.delete();
+        } else {
+            return false;
+        }
+    }
+
+    public static boolean cleanCache(Context context) {
+        try {
+            File dir = context.getCacheDir();
+            deleteDir(dir);
+        } catch (Throwable e) {
+            Log.e("cleanCache", e.toString());
+        }
+        return true;
+    }
+
+    public static boolean cleanPrivateStorage(Context context) {
+        try {
+            for(String type : Arrays.asList("Images", "Videos", "Files", "Recordings")) {
+                File dir = new File(context.getFilesDir().getAbsolutePath(), "/" + type + "/");
+                deleteDir(dir);
+            }
+        } catch (Throwable e) {
+            Log.e("cleanPrivateStorage", e.toString());
+        }
+        return true;
     }
 
     private static Bitmap rotate(Bitmap bitmap, int degree) {
@@ -633,6 +673,7 @@ public class FileBackend {
         }
         message.setRelativeFilePath(message.getUuid() + "." + extension);
         copyFileToPrivateStorage(mXmppConnectionService.getFileBackend().getFile(message), uri);
+        removeImageFromCameraCache(uri);
     }
 
     private String getExtensionFromUri(Uri uri) {
@@ -724,9 +765,19 @@ public class FileBackend {
         }
     }
 
+    public void removeImageFromCameraCache(Uri image) {
+        if (Config.ONLY_INTERNAL_STORAGE &&
+                image.toString().startsWith("content://"
+                    + mXmppConnectionService.getPackageName() + ".files/camera")) {
+            Log.d(Config.LOGTAG, "remove image (" + image.toString() + ") from app cache");
+            mXmppConnectionService.getContentResolver().delete(image, null, null);
+        }
+    }
+
     public void copyImageToPrivateStorage(File file, Uri image) throws FileCopyException {
         Log.d(Config.LOGTAG, "copy image (" + image.toString() + ") to private storage " + file.getAbsolutePath());
         copyImageToPrivateStorage(file, image, 0);
+        removeImageFromCameraCache(image);
     }
 
     public void copyImageToPrivateStorage(Message message, Uri image) throws FileCopyException {

--- a/src/main/java/eu/siacs/conversations/ui/SettingsActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/SettingsActivity.java
@@ -12,6 +12,7 @@ import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
 import android.content.pm.PackageManager;
 
 import android.net.Uri;
+import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
 import android.preference.ListPreference;
@@ -229,15 +230,37 @@ public class SettingsActivity extends XmppActivity implements
 			});
 		}
 
-		if (Config.ONLY_INTERNAL_STORAGE) {
-			final Preference cleanCachePreference = mSettingsFragment.findPreference("clean_cache");
-			if (cleanCachePreference != null) {
-				cleanCachePreference.setOnPreferenceClickListener(preference -> cleanCache());
-			}
+		final Preference cleanCachePreference = mSettingsFragment.findPreference("clean_cache");
+		if (cleanCachePreference != null) {
+			cleanCachePreference.setOnPreferenceClickListener(preference ->
+				{new AsyncTask<Void, Void, Void>() {
+					@Override
+					protected Void doInBackground(Void... params) {
+						FileBackend.cleanCache(SettingsActivity.this);
+						return null;
+					}
+					@Override
+					protected void onPostExecute(Void result) {
+						displayToast(getString(R.string.clean_cache_complete));
+					}
+				}.execute(); return true;});
+		}
 
+		if (Config.ONLY_INTERNAL_STORAGE) {
 			final Preference cleanPrivateStoragePreference = mSettingsFragment.findPreference("clean_private_storage");
 			if (cleanPrivateStoragePreference != null) {
-				cleanPrivateStoragePreference.setOnPreferenceClickListener(preference -> cleanPrivateStorage());
+				cleanPrivateStoragePreference.setOnPreferenceClickListener(preference ->
+				{new AsyncTask<Void, Void, Void>() {
+					@Override
+					protected Void doInBackground(Void... params) {
+						FileBackend.cleanPrivateStorage(SettingsActivity.this);
+						return null;
+					}
+					@Override
+					protected void onPostExecute(Void result) {
+						displayToast(getString(R.string.clean_private_storage_complete));
+					}
+				}.execute(); return true;});
 			}
 		}
 
@@ -269,41 +292,6 @@ public class SettingsActivity extends XmppActivity implements
 
 	private boolean isCallable(final Intent i) {
 		return i != null && getPackageManager().queryIntentActivities(i, PackageManager.MATCH_DEFAULT_ONLY).size() > 0;
-	}
-
-
-	private boolean cleanCache() {
-		Intent intent = new Intent(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
-		intent.setData(Uri.parse("package:" + getPackageName()));
-		startActivity(intent);
-		return true;
-	}
-
-	private boolean cleanPrivateStorage() {
-		for(String type : Arrays.asList("Images", "Videos", "Files", "Recordings")) {
-		        cleanPrivateFiles(type);
-	    }
-		return true;
-	}
-
-	private void cleanPrivateFiles(final String type) {
-		try {
-			File dir = new File(getFilesDir().getAbsolutePath(), "/" + type + "/");
-			File[] array = dir.listFiles();
-			if (array != null) {
-				for (int b = 0; b < array.length; b++) {
-					String name = array[b].getName().toLowerCase();
-					if (name.equals(".nomedia")) {
-						continue;
-					}
-					if (array[b].isFile()) {
-						array[b].delete();
-					}
-				}
-			}
-		} catch (Throwable e) {
-			Log.e("CleanCache", e.toString());
-		}
 	}
 
 	private boolean deleteOmemoIdentities() {

--- a/src/main/java/eu/siacs/conversations/ui/SettingsFragment.java
+++ b/src/main/java/eu/siacs/conversations/ui/SettingsFragment.java
@@ -27,9 +27,7 @@ public class SettingsFragment extends PreferenceFragment {
 		if (!Config.ONLY_INTERNAL_STORAGE) {
 			PreferenceCategory mCategory = (PreferenceCategory) findPreference("security_options");
 			if (mCategory != null) {
-				Preference cleanCache = findPreference("clean_cache");
 				Preference cleanPrivateStorage = findPreference("clean_private_storage");
-				mCategory.removePreference(cleanCache);
 				mCategory.removePreference(cleanPrivateStorage);
 			}
 		}

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -601,10 +601,12 @@
     <string name="blindly_trusted_omemo_keys">Blindly trusted OMEMO keys</string>
     <string name="not_trusted">Untrusted</string>
     <string name="invalid_barcode">Invalid 2D barcode</string>
-    <string name="pref_clean_cache_summary">Clean cache folder (used by Camera Application)</string>
+    <string name="pref_clean_cache_summary">Clean cache folder</string>
+    <string name="clean_cache_complete">Clean cache complete</string>
     <string name="pref_clean_cache">Clean cache</string>
     <string name="pref_clean_private_storage">Clean private storage</string>
     <string name="pref_clean_private_storage_summary">Clean private storage where files are kept (They can be re-downloaded from the server)</string>
+    <string name="clean_private_storage_complete">Clean private storage complete</string>
     <string name="i_followed_this_link_from_a_trusted_source">I followed this link from a trusted source</string>
     <string name="verifying_omemo_keys_trusted_source">You are about to verify the OMEMO keys of %1$s after clicking a link. This is only secure if you followed this link from a trusted source where only %2$s could have published this link.</string>
     <string name="verify_omemo_keys">Verify OMEMO keys</string>

--- a/src/main/res/xml/preferences.xml
+++ b/src/main/res/xml/preferences.xml
@@ -237,10 +237,6 @@
                     android:summary="@string/pref_allow_message_correction_summary"
                     android:title="@string/pref_allow_message_correction" />
                 <Preference
-                    android:key="clean_cache"
-                    android:summary="@string/pref_clean_cache_summary"
-                    android:title="@string/pref_clean_cache" />
-                <Preference
                     android:key="clean_private_storage"
                     android:summary="@string/pref_clean_private_storage_summary"
                     android:title="@string/pref_clean_private_storage" />
@@ -333,6 +329,10 @@
                     android:key="create_backup"
                     android:summary="@string/pref_create_backup_summary"
                     android:title="@string/pref_create_backup" />
+                <Preference
+                    android:key="clean_cache"
+                    android:summary="@string/pref_clean_cache_summary"
+                    android:title="@string/pref_clean_cache" />
             </PreferenceCategory>
         </PreferenceScreen>
 


### PR DESCRIPTION
I propose to rework the clean-cache- and clean-private-storage-functionality:

1. remove the camera files automatically after image has been copied to internal storage

1. provide clean-cache-functionality independently from Config.ONLY_INTERNAL_STORAGE

1. clean-cache-functionality works without user interaction

1. clean-cache- and clean-private-storage-functionality as AsyncTasks

1. move the corresponding methods as static methods to FileBackend