### PR TITLE
Create a notification if the delivery fails

### DIFF
--- a/src/main/java/eu/siacs/conversations/services/XmppConnectionService.java
+++ b/src/main/java/eu/siacs/conversations/services/XmppConnectionService.java
@@ -3757,6 +3757,11 @@ public class XmppConnectionService extends Service {
 		if (status == Message.STATUS_SEND_RECEIVED && c == Message.STATUS_SEND_DISPLAYED) {
 			return;
 		}
+
+		if (status == Message.STATUS_SEND_FAILED) {
+			mNotificationService.createDeliveryFailedNotification(message.getConversation(), errorMessage);
+        	}
+
 		message.setErrorMessage(errorMessage);
 		message.setStatus(status);
 		databaseBackend.updateMessage(message, false);

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -77,6 +77,7 @@
     <string name="not_in_roster">The contact is not in your roster. Would you like to add it?</string>
     <string name="add_contact">Add contact</string>
     <string name="send_failed">delivery failed</string>
+    <string name="send_failed_notif">Delivery failed</string>
     <string name="preparing_image">Preparing image for transmission</string>
     <string name="preparing_images">Preparing images for transmission</string>
     <string name="sharing_files_please_wait">Sharing files. Please wait…</string>


### PR DESCRIPTION
Fixes  #3394. Fixes #2191. Definitely improves the situation of #3340, 

This is an early, barebones implementation, which will still need some love. I'm submitting it right now to allow discussion about the implementation details.
This is my second contact with Android development and first contact with the Android notifications (previously I've developed software for other platforms) so please pardon my possible lack of experience here.

These notifications are meant for exceptional situations, e.g. OS error, internal server error or server configuration issue. This isn't actually the case because  #3340 is not an exceptional situation and network failure during HTTP upload will definitely need a better UX in the future. (but I don't have an idea for a better UX here other than a custom error message)

Issues which still need to be addressed before merging 
* [ ] the icon in the notification is gray instead of green (why?)
* [x] when the notification is clicked, the notification doesn't disappear (because `createContentIntent` doesn't set `Intent.FLAG_ACTIVITY_CLEAR_TASK`)
* [x] if multiple delivery failures occur, the notification is replaced: probably a multiple-entry notification should be created - how? Should I use `NotificationCompat.InboxStyle`?
* [x] what if the app is closed or the system restarted, the notification won't be replayed. This is inconsistent with the behavior of the message notifications and is difficult to address, since we don't have read/unread status for delivery failures. Since this is meant for exceptional situations, I suggest to ignore it, unless you have any good idea.

Let me know what you think about those issues.
