### PR TITLE
Foreground service on by default

### DIFF
--- a/src/main/res/values/defaults.xml
+++ b/src/main/res/values/defaults.xml
@@ -30,7 +30,7 @@
     <bool name="manually_change_presence">false</bool>
     <bool name="away_when_screen_off">false</bool>
     <bool name="autojoin">true</bool>
-    <bool name="enable_foreground_service">false</bool>
+    <bool name="enable_foreground_service">true</bool>
     <bool name="never_send">false</bool>
     <bool name="validate_hostname">false</bool>
     <bool name="show_qr_code_scan">true</bool>


### PR DESCRIPTION
Most will need this anyway (or they can't control it on Oreo and later) or they can disable it, but I see F-Droid users with it off (since it's default) that disconnect all the time and don't get timely messages.