### PR TITLE
fix local channel discovery if DOMAIN_LOCK is set

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/ChannelDiscoveryActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ChannelDiscoveryActivity.java
@@ -263,7 +263,7 @@ public class ChannelDiscoveryActivity extends XmppActivity implements MenuItem.O
     }
 
     public void joinChannelSearchResult(String selectedAccount, Room result) {
-        final Jid jid = Config.DOMAIN_LOCK == null ? Jid.ofEscaped(selectedAccount) : Jid.ofEscaped(selectedAccount, Config.DOMAIN_LOCK, null);
+        final Jid jid = Jid.ofEscaped(selectedAccount);
         final boolean syncAutoJoin = getBooleanPreference("autojoin", R.bool.autojoin);
         final Account account = xmppConnectionService.findAccountByJid(jid);
         final Conversation conversation = xmppConnectionService.findOrCreateConversation(account, result.getRoom(), true, true, true);


### PR DESCRIPTION
I see the following error with local server channel discovery and DOMAIN_LOCK != null:

```
java.lang.IllegalArgumentException: org.jxmpp.stringprep.XmppStringprepException: Localpart must not contain '@'
        at eu.siacs.conversations.xmpp.Jid$-CC.ofEscaped(Jid.java:55)
        at eu.siacs.conversations.ui.ChannelDiscoveryActivity.joinChannelSearchResult(ChannelDiscoveryActivity.java:266)
        at eu.siacs.conversations.ui.ChannelDiscoveryActivity.onChannelSearchResult(ChannelDiscoveryActivity.java:230)
```

This PR is supposed to fix it.