### PR TITLE
Allow 3rd-party applications to know about an incoming call

### DIFF
--- a/src/main/java/eu/siacs/conversations/services/NotificationService.java
+++ b/src/main/java/eu/siacs/conversations/services/NotificationService.java
@@ -602,9 +602,6 @@ public class NotificationService {
         } catch (SecurityException e) {
             Log.d(Config.LOGTAG, "unable to use custom notification sound " + uri.toString());
         }
-        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            mBuilder.setCategory(Notification.CATEGORY_MESSAGE);
-        }
         mBuilder.setPriority(NotificationCompat.PRIORITY_HIGH);
         setNotificationColor(mBuilder);
         mBuilder.setLights(LED_COLOR, 2000, 3000);


### PR DESCRIPTION
Set the incoming call notification category back to `CATEGORY_CALL`. This is what other apps like WhatsApp and Telegram are doing. Without a proper category 3rd-party apps are not able to notify a user about a call. For example, [Gadgetbridge](https://gadgetbridge.org/) currently doesn't start an incoming call notification/vibration on a smart watch during an incoming call in Conversations.

I don't know why the category was previously overridden as `CATEGORY_MESSAGE` in `modifyIncomingCall()`, so I'm not sure whether this breaks anything.

Tested with [Gadgetbridge](https://gadgetbridge.org/).