### PR TITLE
Support sending messages with ctrl+enter.

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
@@ -32,6 +32,7 @@ import android.util.Log;
 import android.view.ContextMenu;
 import android.view.ContextMenu.ContextMenuInfo;
 import android.view.Gravity;
+import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -2734,10 +2735,10 @@ public class ConversationFragment extends XmppFragment implements EditMessage.Ke
     }
 
     @Override
-    public boolean onEnterPressed() {
+    public boolean onEnterPressed(KeyEvent event) {
         SharedPreferences p = PreferenceManager.getDefaultSharedPreferences(getActivity());
         final boolean enterIsSend = p.getBoolean("enter_is_send", getResources().getBoolean(R.bool.enter_is_send));
-        if (enterIsSend) {
+        if (enterIsSend || event.isCtrlPressed()) {
             sendMessage();
             return true;
         } else {

--- a/src/main/java/eu/siacs/conversations/ui/widget/EditMessage.java
+++ b/src/main/java/eu/siacs/conversations/ui/widget/EditMessage.java
@@ -57,7 +57,7 @@ public class EditMessage extends EmojiWrapperEditText {
     public boolean onKeyDown(int keyCode, KeyEvent e) {
         if (keyCode == KeyEvent.KEYCODE_ENTER && !e.isShiftPressed()) {
             lastInputWasTab = false;
-            if (keyboardListener != null && keyboardListener.onEnterPressed()) {
+            if (keyboardListener != null && keyboardListener.onEnterPressed(e)) {
                 return true;
             }
         } else if (keyCode == KeyEvent.KEYCODE_TAB && !e.isAltPressed() && !e.isCtrlPressed()) {
@@ -191,7 +191,7 @@ public class EditMessage extends EmojiWrapperEditText {
     }
 
     public interface KeyboardListener {
-        boolean onEnterPressed();
+        boolean onEnterPressed(KeyEvent event);
 
         void onTypingStarted();
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -401,7 +401,7 @@
     <string name="mark_as_read">Mark as read</string>
     <string name="pref_input_options">Input</string>
     <string name="pref_enter_is_send">Enter is send</string>
-    <string name="pref_enter_is_send_summary">Use enter key to send message</string>
+    <string name="pref_enter_is_send_summary">Use enter key to send message. You can always use ctrl+enter to send message, even if this option is disabled.</string>
     <string name="pref_display_enter_key">Show enter key</string>
     <string name="pref_display_enter_key_summary">Change the emoticons key to an enter key</string>
     <string name="audio">audio</string>


### PR DESCRIPTION
Currently Conversations lacks any keyboard shortcut to send a message if enter_is_send is disabled.

KeyboardListener has been extended to include the original KeyEvent as an argument.

-------------------------

If passing the whole `KeyEvent` is too much, we can use `getMetaState()` and pass the bitflags of meta keys. Closes #3827.