### PR TITLE
Change handling of empty lines in Paste as Quote

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/widget/EditMessage.java
+++ b/src/main/java/eu/siacs/conversations/ui/widget/EditMessage.java
@@ -142,7 +142,7 @@ public class EditMessage extends EmojiWrapperEditText {
     }
 
     public void insertAsQuote(String text) {
-        text = text.replaceAll("(\n *){2,}", "\n").replaceAll("(^|\n)", "$1> ").replaceAll("\n$", "");
+        text = text.replaceAll("(^|\n)", "$1> ").replaceAll("\n$", "");
         Editable editable = getEditableText();
         int position = getSelectionEnd();
         if (position == -1) position = editable.length();


### PR DESCRIPTION
I'm trying to fix the problem I reported in #3876, although we haven't agreed that it is a problem. :-) This modifies code originally committed as #2127.

This PR removes the first `replaceAll()` in `insertAsQuote()` which looks for two or more "line feed" (`\n`) characters optionally separated  by spaces with a single line feed. If this PR is merged, text will be pasted with the same white space it has before quoting.


We might want to think about how this function should work (that is, for a set of input texts, what should the output be) and then rework it to do that. For example, I'm not sure the final `.replaceAll("\n$", "")` is doing what it should be. I think it's supposed to strip remaining empty lines at the end of the text but for my tests strings it doesn't seem to. (It does do that if you move it before the "insert `>`" step.)

So that is to say, I'm happy to keep tweaking this PR until it meets your approval!