### PR TITLE
Enable the android:largeHeap flag

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -57,6 +57,7 @@
         android:hardwareAccelerated="true"
         android:icon="@mipmap/new_launcher"
         android:label="@string/app_name"
+        android:largeHeap="true"
         android:networkSecurityConfig="@xml/network_security_configuration"
         android:theme="@style/ConversationsTheme"
         tools:replace="android:label"


### PR DESCRIPTION
- With large accounts (such as mine), Conversations starts hitting up against
  the default heap limit pretty quickly, at which point it grinds to a halt as
  GC pause times increase.
- Furthermore, it's impossible to complete a backup with such an account, since
  Conversations will just run out of memory before the backup can complete.
- Enabling the `android:largeHeap` flag asks the OS for a bit more memory, which
  hopefully alleviates the problem for larger accounts.