### PR TITLE
Fix various memory leaks reported by LeakCanary

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
@@ -1048,6 +1048,14 @@ public class ConversationFragment extends XmppFragment implements EditMessage.Ke
 
         return binding.getRoot();
     }
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        Log.d(Config.LOGTAG,"ConversationFragment.onDestroyView()");
+        messageListAdapter.setOnContactPictureClicked(null);
+        messageListAdapter.setOnContactPictureLongClicked(null);
+        messageListAdapter.setOnQuoteListener(null);
+    }
 
     private void quoteText(String text) {
         if (binding.textinput.isEnabled()) {

--- a/src/main/java/eu/siacs/conversations/ui/ConversationsOverviewFragment.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConversationsOverviewFragment.java
@@ -192,7 +192,7 @@ public class ConversationsOverviewFragment extends XmppFragment {
 		}
 	};
 
-	private ItemTouchHelper touchHelper = new ItemTouchHelper(callback);
+	private ItemTouchHelper touchHelper;
 
 	public static Conversation getSuggestion(Activity activity) {
 		final Conversation exception;
@@ -242,7 +242,20 @@ public class ConversationsOverviewFragment extends XmppFragment {
 			throw new IllegalStateException("Trying to attach fragment to activity that is not an XmppActivity");
 		}
 	}
+	@Override
+	public void onDestroyView() {
+		Log.d(Config.LOGTAG,"ConversationsOverviewFragment.onDestroyView()");
+		super.onDestroyView();
+		this.binding = null;
+		this.conversationsAdapter = null;
+		this.touchHelper = null;
+	}
+	@Override
+	public void onDestroy() {
+		Log.d(Config.LOGTAG,"ConversationsOverviewFragment.onDestroy()");
+		super.onDestroy();
 
+	}
 	@Override
 	public void onPause() {
 		Log.d(Config.LOGTAG,"ConversationsOverviewFragment.onPause()");
@@ -278,6 +291,7 @@ public class ConversationsOverviewFragment extends XmppFragment {
 		});
 		this.binding.list.setAdapter(this.conversationsAdapter);
 		this.binding.list.setLayoutManager(new LinearLayoutManager(getActivity(),LinearLayoutManager.VERTICAL,false));
+		this.touchHelper = new ItemTouchHelper(this.callback);
 		this.touchHelper.attachToRecyclerView(this.binding.list);
 		return binding.getRoot();
 	}


### PR DESCRIPTION
- In some places, we weren't nulling out references to destroyed objects. This
  fixes that.
- (These were all discovered via LeakCanary instrumentation, and the fixes are
  hopefully rather straightforward-looking.)