### PR TITLE
Do not end the call when the back button is pressed.

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/RtpSessionActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/RtpSessionActivity.java
@@ -456,12 +456,6 @@ public class RtpSessionActivity extends XmppActivity implements XmppConnectionSe
     }
 
     @Override
-    public void onBackPressed() {
-        super.onBackPressed();
-        endCall();
-    }
-
-    @Override
     public void onUserLeaveHint() {
         super.onUserLeaveHint();
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && deviceSupportsPictureInPicture()) {


### PR DESCRIPTION
This matches the behavior of the built-in phone application of LineageOS.

Ending the call when the back button is pressed makes it quite easy to end calls by mistake.

### Alternative approaches
* ignore the back key. This is the behavior of the stock phone app on a Samsung Oreo ROM.
* display the toast on first back key press, end the call on a second key press

### Hacktoberfest
If you appreciate this PR, please [tag it as `hacktoberfest-accepted`](https://hacktoberfest.digitalocean.com/hacktoberfest-update). Thanks ;)