### PR TITLE
Fix search on API22 and below

### DIFF
--- a/src/main/java/eu/siacs/conversations/utils/FtsUtils.java
+++ b/src/main/java/eu/siacs/conversations/utils/FtsUtils.java
@@ -66,7 +66,7 @@ public class FtsUtils {
 			} else if (term.contains("*") || term.startsWith("-")) {
 				builder.append(term);
 			} else {
-				builder.append('*').append(term).append('*');
+				builder.append(term).append('*');
 			}
 		}
 		return builder.toString();


### PR DESCRIPTION
Conversations has been prepending an asterisk to every word in fulltext search.
On SQLite 3.8.6 and below that causes the query to never return anything.
Otherwise it is a symbol which is completely ignored.