### PR TITLE
Add ellipsis to menu entries indicating following dialogue

### DIFF
--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -79,8 +79,8 @@
     <string name="preparing_image">Getting ready to send image</string>
     <string name="preparing_images">Getting ready to send images</string>
     <string name="sharing_files_please_wait">Sharing files. Please wait…</string>
-    <string name="action_clear_history">Clear history</string>
-    <string name="clear_conversation_history">Clear Conversation History</string>
+    <string name="action_clear_history">Clear history…</string>
+    <string name="clear_conversation_history">Clear conversation history</string>
     <string name="clear_histor_msg">Do you want to delete all messages in this conversation?\n\n<b>Warning:</b> This will not influence messages stored on other devices or servers.</string>
     <string name="delete_file_dialog">Delete file</string>
     <string name="delete_file_dialog_msg">Are you sure you want to delete this file?\n\n<b>Warning:</b> This will not delete copies of this file that are stored on other devices or servers. </string>
@@ -328,7 +328,7 @@
     <string name="choose_file">Choose file</string>
     <string name="receiving_x_file">Receiving %1$s (%2$d%% completed)</string>
     <string name="download_x_file">Download %s</string>
-    <string name="delete_x_file">Delete %s</string>
+    <string name="delete_x_file">Delete %s…</string>
     <string name="file">file</string>
     <string name="open_x_file">Open %s</string>
     <string name="sending_file">sending (%1$d%% completed)</string>


### PR DESCRIPTION
A user who is new to XMPP asked what the "clear history" entry does, i.e. if messages are deleted or just hidden and where they are deleted.

I think part of this confusion comes from the fact that the menu entry doesn't follow the user interface convention of appending an ellipsis (…) if selecting the entry opens a dialogue (in this particular case a dialogue that answers the user's questions).

Without this hint, people may be hesitant to just tap the entry out of worry that the history would be deleted without explanation or confirmation.

In modern UIs, it has become common not to ask for confirmation with a dialogue and offer an undo operation instead. Then the ellipsis could be left out, but as long as this isn't implemented, the ellipsis is a very easy usability improvement.

I have adapted only the entries followed by a confirmation dialogue that I knew off the top of my head. If you can think of others, they could be changed as well before merging.