### PR TITLE
Add provision for private notifications

### DIFF
--- a/src/main/java/eu/siacs/conversations/Config.java
+++ b/src/main/java/eu/siacs/conversations/Config.java
@@ -55,7 +55,6 @@ public final class Config {
 
 
     //Notification settings
-    public static final boolean HIDE_MESSAGE_TEXT_IN_NOTIFICATION = false;
     public static final boolean ALWAYS_NOTIFY_BY_DEFAULT = false;
     public static final boolean SUPPRESS_ERROR_NOTIFICATION = false;
 

--- a/src/main/java/eu/siacs/conversations/services/NotificationService.java
+++ b/src/main/java/eu/siacs/conversations/services/NotificationService.java
@@ -272,6 +272,10 @@ public class NotificationService {
         }
     }
 
+    public boolean privateNotificationsEnabled() {
+        return mXmppConnectionService.getBooleanPreference("enable_private_notifications", R.bool.enable_private_notifications);
+    }
+
     private AtomicInteger getBacklogMessageCounter(Conversation conversation) {
         synchronized (mBacklogMessageCounter) {
             if (!mBacklogMessageCounter.containsKey(conversation)) {
@@ -670,7 +674,7 @@ public class NotificationService {
                 conversation = (Conversation) messages.get(0).getConversation();
                 final String name = conversation.getName().toString();
                 SpannableString styledString;
-                if (Config.HIDE_MESSAGE_TEXT_IN_NOTIFICATION) {
+                if (privateNotificationsEnabled()) {
                     int count = messages.size();
                     styledString = new SpannableString(name + ": " + mXmppConnectionService.getResources().getQuantityString(R.plurals.x_messages, count, count));
                     styledString.setSpan(new StyleSpan(Typeface.BOLD), 0, name.length(), 0);
@@ -708,7 +712,7 @@ public class NotificationService {
             mBuilder.setLargeIcon(mXmppConnectionService.getAvatarService()
                     .get(conversation, AvatarService.getSystemUiAvatarSize(mXmppConnectionService)));
             mBuilder.setContentTitle(conversation.getName());
-            if (Config.HIDE_MESSAGE_TEXT_IN_NOTIFICATION) {
+            if (privateNotificationsEnabled()) {
                 int count = messages.size();
                 mBuilder.setContentText(mXmppConnectionService.getResources().getQuantityString(R.plurals.x_messages, count, count));
             } else {

--- a/src/main/res/values/defaults.xml
+++ b/src/main/res/values/defaults.xml
@@ -13,6 +13,7 @@
     <bool name="vibrate_on_notification">true</bool>
     <bool name="led">true</bool>
     <bool name="enable_quiet_hours">false</bool>
+    <bool name="enable_private_notifications">false</bool>
     <string name="notification_ringtone">content://settings/system/notification_sound</string>
     <string name="incoming_call_ringtone">content://settings/system/ringtone</string>
     <integer name="grace_period">144</integer>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -119,6 +119,7 @@
     <string name="pref_notification_sound">Notification sound</string>
     <string name="pref_notification_sound_summary">Notification sound for new messages</string>
     <string name="pref_call_ringtone_summary">Ringtone for incoming call</string>
+    <string name="pref_private_notifications_summary">Hide sensitive content in notifications</string>
     <string name="pref_notification_grace_period">Grace Period</string>
     <string name="pref_notification_grace_period_summary">The length of time notifications are silenced after detecting activity on one of your other devices.</string>
     <string name="pref_advanced_options">Advanced</string>

--- a/src/main/res/xml/preferences.xml
+++ b/src/main/res/xml/preferences.xml
@@ -138,6 +138,11 @@
             android:ringtoneType="ringtone"
             android:summary="@string/pref_call_ringtone_summary"
             android:title="@string/pref_ringtone" />
+        <CheckBoxPreference
+            android:defaultValue="@bool/enable_private_notifications"
+            android:key="enable_private_notifications"
+            android:summary="@string/pref_private_notifications_summary"
+            android:title="Private Notifications" />
     </PreferenceCategory>
     <PreferenceCategory
         android:key="attachments"


### PR DESCRIPTION
There has been a long standing demand of private notifications: #265 
This pull request adds a provision for the user to get notified about the received messages but not reveal the contents.