### PR TITLE
Use account display name in /me command in one-to-one chats

### DIFF
--- a/src/main/java/eu/siacs/conversations/utils/UIHelper.java
+++ b/src/main/java/eu/siacs/conversations/utils/UIHelper.java
@@ -18,6 +18,7 @@ import java.util.Locale;
 import eu.siacs.conversations.Config;
 import eu.siacs.conversations.R;
 import eu.siacs.conversations.crypto.axolotl.AxolotlService;
+import eu.siacs.conversations.entities.Account;
 import eu.siacs.conversations.entities.Contact;
 import eu.siacs.conversations.entities.Conversation;
 import eu.siacs.conversations.entities.Conversational;
@@ -521,7 +522,11 @@ public class UIHelper {
             if (conversation instanceof Conversation && conversation.getMode() == Conversation.MODE_MULTI) {
                 return ((Conversation) conversation).getMucOptions().getSelf().getName();
             } else {
-                final Jid jid = conversation.getAccount().getJid();
+                final Account account = conversation.getAccount();
+                final Jid jid = account.getJid();
+                if (account.getDisplayName() != null) {
+                    return account.getDisplayName();
+                }
                 return jid.getLocal() != null ? jid.getLocal() : jid.getDomain().toString();
             }
         }


### PR DESCRIPTION
When processing `/me` messages which are both sent to and received from MUC's, Conversations will render the message using the user's alias name within that MUC chat, so participants can choose the name displayed in their messages in the MUC. For example, if my alias within a MUC is `molly`, then sending the message "/me is using conversations.im" to that MUC will locally be rendered as "*molly* is using conversations.im".

In a direct chat with another user, incoming `/me` messages are rendered using the remote user's contact name, if set. For example, if I receive the message "/me is using dino.im" from another user `jane@example.com`, who is in my roster as "Jane Doe", then the message will locally be rendered as "*Jane Doe* is using dino.im". However, when *sending* `/me` messages in a direct chat, the message is rendered using the user part of the sending account's JID; e.g., if my JID is `mm@example.com`, then sending the message "/me is using conversations.im" is rendered as "*mm* is using conversations.im".

This patch changes the latter behaviour so that Conversations will first attempt to use the account's display name if one is set, before falling back to the previous behaviour. In the above example, this means now means that sending a message "/me is using conversations.im" from an account with JID `mm@example.com` and local display name "Molly Miller" will be rendered as "*Molly Miller* is using conversations.im".