### PR TITLE
Always ask to disable battery optimisations

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/ConversationsActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConversationsActivity.java
@@ -218,8 +218,7 @@ public class ConversationsActivity extends XmppActivity implements OnConversatio
     }
 
     private void openBatteryOptimizationDialogIfNeeded() {
-        if (hasAccountWithoutPush()
-                && isOptimizingBattery()
+        if (isOptimizingBattery()
                 && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M
                 && getPreferences().getBoolean(getBatteryOptimizationPreferenceKey(), true)) {
             AlertDialog.Builder builder = new AlertDialog.Builder(this);
@@ -240,15 +239,6 @@ public class ConversationsActivity extends XmppActivity implements OnConversatio
             dialog.setCanceledOnTouchOutside(false);
             dialog.show();
         }
-    }
-
-    private boolean hasAccountWithoutPush() {
-        for (Account account : xmppConnectionService.getAccounts()) {
-            if (account.getStatus() == Account.State.ONLINE && !xmppConnectionService.getPushManagementService().available(account)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private void notifyFragmentOfBackendConnected(@IdRes int id) {

--- a/src/main/java/eu/siacs/conversations/ui/EditAccountActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/EditAccountActivity.java
@@ -1012,7 +1012,7 @@ public class EditAccountActivity extends OmemoActivity implements OnAccountUpdat
         if (this.mAccount.isOnlineAndConnected() && !this.mFetchingAvatar) {
             Features features = this.mAccount.getXmppConnection().getFeatures();
             this.binding.stats.setVisibility(View.VISIBLE);
-            boolean showBatteryWarning = !xmppConnectionService.getPushManagementService().available(mAccount) && isOptimizingBattery();
+            boolean showBatteryWarning = isOptimizingBattery();
             boolean showDataSaverWarning = isAffectedByDataSaver();
             showOsOptimizationWarning(showBatteryWarning, showDataSaverWarning);
             this.binding.sessionEst.setText(UIHelper.readableTimeDifferenceFull(this, this.mAccount.getXmppConnection()


### PR DESCRIPTION
...as OEMs kill [1] the app and ignore Push messages and never wake up the app.

My experience _(and for others in the support group)_ goes like this:
* recommend Quicksy/Snikket/Conversations for Play users
* they install, we make contact
* everything works for a day
* the second day they appear offline
* no matter 1:1/group messages are not acknowledged
* I send an SMS
* they open the app, get the messages
* next day they go offline again
* stay offline for the next 4 days

If I'm able to meet with them, I can:
* ask for their device
* explain the issue _($hitty OEMs, whitelists for big money corps, etc)_
* while trying to confusingly navigate Android settings
* set autostart to manual
* put the app on the ignore battery optimizations list

If I'm not able to meet them? Nothing, no fix, send SMS to hopefully open the app...

This PR builds and works fine, but I can't test an actual Play install for obvious reasons.

[1] https://dontkillmyapp.com