### PR TITLE
Add setting to avoid confirmation of attachment deletion

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
@@ -1823,22 +1823,33 @@ public class ConversationFragment extends XmppFragment implements EditMessage.Ke
     }
 
 
+    private void _deleteFile(final Message message) {
+        if (activity.xmppConnectionService.getFileBackend().deleteFile(message)) {
+            message.setDeleted(true);
+            activity.xmppConnectionService.evictPreview(message.getUuid());
+            activity.xmppConnectionService.updateMessage(message, false);
+            activity.onConversationsListItemUpdated();
+            refresh();
+        }
+    }
+
     private void deleteFile(final Message message) {
+
+        boolean prefConfirm = activity.xmppConnectionService.getBooleanPreference("confirm_delete_attachment", R.bool.confirm_delete_attachment);
+
+        if(!prefConfirm) {
+            _deleteFile(message);
+            return;
+        }
+
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
         builder.setNegativeButton(R.string.cancel, null);
         builder.setTitle(R.string.delete_file_dialog);
         builder.setMessage(R.string.delete_file_dialog_msg);
         builder.setPositiveButton(R.string.confirm, (dialog, which) -> {
-            if (activity.xmppConnectionService.getFileBackend().deleteFile(message)) {
-                message.setDeleted(true);
-                activity.xmppConnectionService.evictPreview(message.getUuid());
-                activity.xmppConnectionService.updateMessage(message, false);
-                activity.onConversationsListItemUpdated();
-                refresh();
-            }
+            _deleteFile(message);
         });
         builder.create().show();
-
     }
 
     private void resendMessage(final Message message) {

--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -956,4 +956,6 @@
     <string name="unable_to_parse_invite">Einladung kann nicht gelesen werden</string>
     <string name="server_does_not_support_easy_onboarding_invites">Server unterstützt keine Generierung von Einladungen</string>
     <string name="no_active_accounts_support_this">Keine aktiven Konten unterstützen diese Funktion</string>
+    <string name="confirm_delete_attachment_summary">Soll das Löschen von Attachments immer bestätigt werden?</string>
+    <string name="pref_confirm_delete_attachment">Löschen von Attachments in Chats</string>
 </resources>

--- a/src/main/res/values/bools.xml
+++ b/src/main/res/values/bools.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <bool name="show_avatar_incoming_call">true</bool>
+    <bool name="confirm_delete_attachment">true</bool>
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -959,4 +959,6 @@
     <string name="unable_to_parse_invite">Unable to parse invite</string>
     <string name="server_does_not_support_easy_onboarding_invites">Server does not support generating invites</string>
     <string name="no_active_accounts_support_this">No active accounts support this feature</string>
+    <string name="confirm_delete_attachment_summary">Always confirm deletion of attachments?</string>
+    <string name="pref_confirm_delete_attachment">Deletetion of Attachments</string>
 </resources>

--- a/src/main/res/xml/preferences.xml
+++ b/src/main/res/xml/preferences.xml
@@ -134,6 +134,11 @@
             android:key="use_share_location_plugin"
             android:summary="@string/pref_use_share_location_plugin_summary"
             android:title="@string/pref_use_share_location_plugin" />
+        <CheckBoxPreference
+            android:defaultValue="@bool/confirm_delete_attachment"
+            android:key="confirm_delete_attachment"
+            android:summary="@string/confirm_delete_attachment_summary"
+            android:title="@string/pref_confirm_delete_attachment" />
         <ListPreference
             android:defaultValue="@string/picture_compression"
             android:entries="@array/picture_compression_entries"


### PR DESCRIPTION
This PR adds a setting (confirm_delete_attachment; default TRUE) to let the user decide to delete attachments without an extra confirmation. I find it very useful...