### PR TITLE
Remove Renomination from WebRTC Options

### DIFF
--- a/src/main/java/eu/siacs/conversations/xmpp/jingle/SessionDescription.java
+++ b/src/main/java/eu/siacs/conversations/xmpp/jingle/SessionDescription.java
@@ -24,7 +24,7 @@ public class SessionDescription {
     public final static String LINE_DIVIDER = "\r\n";
     private final static String HARDCODED_MEDIA_PROTOCOL = "UDP/TLS/RTP/SAVPF"; //probably only true for DTLS-SRTP aka when we have a fingerprint
     private final static int HARDCODED_MEDIA_PORT = 9;
-    private final static String HARDCODED_ICE_OPTIONS = "trickle renomination";
+    private final static String HARDCODED_ICE_OPTIONS = "trickle";
     private final static String HARDCODED_CONNECTION = "IN IP4 0.0.0.0";
 
     public final int version;


### PR DESCRIPTION
This is a feature of WebRTC that's [not standardized][1] and only supported by libwebrtc. Since there's no support in jingle for passing this capability from one peer to another, we're currently hard-coding this option into both the local candidate and also the remote candidate so they can use it.

But I'm trying to call a user that isn't using WebRTC, and renomination is causing the call to stay in "connecting..." state for 10 or 20 seconds, sometimes longer, while both sides wait for the other to nominate something based on their individual beliefs about the standards they're using.

Removing this seems to make connecting relatively instantaneous.

If we want to reintroduce this feature, we should probably make a XEP so the peers can negotiate honestly about it, and only use it if both sides truly support the feature.

Trickle is in a similar situation, but doesn't seem to be as troublesome so far.
There is a [draft spec][2] for Trickle as well, but it's got some more details and revisions, and there's also a [deferred XEP][3] for how Jingle would interact with it, and how it would be discovered.

But importantly, Trickle doesn't appear to be in the way of what I'm trying to accomplish, so I'm not as interested in fixing it :sweat_smile: 

[1]: https://datatracker.ietf.org/doc/html/draft-thatcher-ice-renomination-01
[2]: https://tools.ietf.org/html/draft-ietf-ice-trickle-21
[3]: https://xmpp.org/extensions/xep-0371.html