### PR TITLE
display jid in calls

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/RtpSessionActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/RtpSessionActivity.java
@@ -361,6 +361,7 @@ public class RtpSessionActivity extends XmppActivity implements XmppConnectionSe
         } else if (asList(ACTION_MAKE_VIDEO_CALL, ACTION_MAKE_VOICE_CALL).contains(action)) {
             proposeJingleRtpSession(account, with, actionToMedia(action));
             binding.with.setText(account.getRoster().getContact(with).getDisplayName());
+            binding.withJid.setText(with.asBareJid());
         } else {
             throw new IllegalStateException("received onNewIntent without sessionId");
         }
@@ -385,6 +386,7 @@ public class RtpSessionActivity extends XmppActivity implements XmppConnectionSe
         } else if (asList(ACTION_MAKE_VIDEO_CALL, ACTION_MAKE_VOICE_CALL).contains(action)) {
             proposeJingleRtpSession(account, with, actionToMedia(action));
             binding.with.setText(account.getRoster().getContact(with).getDisplayName());
+            binding.withJid.setText(with.asBareJid());
         } else if (Intent.ACTION_VIEW.equals(action)) {
             final String extraLastState = intent.getStringExtra(EXTRA_LAST_REPORTED_STATE);
             final RtpEndUserState state = extraLastState == null ? null : RtpEndUserState.valueOf(extraLastState);
@@ -397,6 +399,7 @@ public class RtpSessionActivity extends XmppActivity implements XmppConnectionSe
                 invalidateOptionsMenu();
             }
             binding.with.setText(account.getRoster().getContact(with).getDisplayName());
+            binding.withJid.setText(with.asBareJid());
             if (xmppConnectionService.getJingleConnectionManager().fireJingleRtpConnectionStateUpdates()) {
                 return;
             }
@@ -574,6 +577,7 @@ public class RtpSessionActivity extends XmppActivity implements XmppConnectionSe
             putScreenInCallMode();
         }
         binding.with.setText(getWith().getDisplayName());
+        binding.withJid.setText(with.asBareJid());
         updateVideoViews(currentState);
         updateStateDisplay(currentState, media);
         updateVerifiedShield(verified && STATES_SHOWING_SWITCH_TO_CHAT.contains(currentState));
@@ -598,6 +602,7 @@ public class RtpSessionActivity extends XmppActivity implements XmppConnectionSe
         updateVerifiedShield(false);
         invalidateOptionsMenu();
         binding.with.setText(account.getRoster().getContact(with).getDisplayName());
+        binding.withJid.setText(with.asBareJid());
     }
 
     private void reInitializeActivityWithRunningRtpSession(final Account account, Jid with, String sessionId) {

--- a/src/main/res/layout/activity_rtp_session.xml
+++ b/src/main/res/layout/activity_rtp_session.xml
@@ -55,10 +55,23 @@
                 android:layout_marginLeft="16dp"
                 android:layout_marginTop="0dp"
                 android:layout_marginRight="16dp"
-                android:layout_marginBottom="32dp"
+                android:layout_marginBottom="16dp"
                 android:textAppearance="@style/TextAppearance.Conversations.Display2"
                 android:textColor="@color/white"
                 tools:text="Juliet Capulet" />
+
+            <TextView
+                android:id="@+id/with_jid"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@id/with"
+                android:layout_marginLeft="16dp"
+                android:layout_marginTop="0dp"
+                android:layout_marginRight="16dp"
+                android:layout_marginBottom="32dp"
+                android:textAppearance="@style/TextAppearance.Conversations.Title"
+                android:textColor="@color/white"
+                tools:text="juliet@capulet.lit" />
 
         </com.google.android.material.appbar.AppBarLayout>
 


### PR DESCRIPTION
I'm not sure this is the best way to accomplish this but there are many situations where i would like to see the jid during a call.

One of the main use cases is that I use conversations for calling with [jmp.chat](https://jmp.chat) and it's helpful to see the number.