### PR TITLE
Add a toast when Tor is enabled stating that audio/video will be disabled

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/EditAccountActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/EditAccountActivity.java
@@ -243,6 +243,9 @@ public class EditAccountActivity extends OmemoActivity implements OnAccountUpdat
                         binding.port.requestFocus();
                         return;
                     }
+                    if(mAccount != null && !hostname.equals(mAccount.getServer()) && !mAccount.isOnion() && hostname.endsWith(".onion")) {
+                        Toast.makeText(EditAccountActivity.this, R.string.audio_video_disabled_tor, Toast.LENGTH_LONG).show();
+                    }
                 }
             } else {
                 hostname = null;

--- a/src/main/java/eu/siacs/conversations/ui/SettingsActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/SettingsActivity.java
@@ -386,6 +386,9 @@ public class SettingsActivity extends XmppActivity implements
 		} else if (name.equals("use_tor")) {
 			reconnectAccounts();
 			xmppConnectionService.reinitializeMuclumbusService();
+			if(getBooleanPreference("use_tor", R.bool.use_tor)) {
+				displayToast(getString(R.string.audio_video_disabled_tor));
+			}
 		} else if (name.equals(AUTOMATIC_MESSAGE_DELETION)) {
 			xmppConnectionService.expireOldMessages(true);
 		} else if (name.equals(THEME)) {

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -966,4 +966,5 @@
     <string name="backup_started_message">The backup has been started. You’ll get a notification once it has been completed.</string>
     <string name="unable_to_enable_video">Unable to enable video.</string>
     <string name="plain_text_document">Plain text document</string>
+    <string name="audio_video_disabled_tor">Audio/Video calls will be unavailable while over Tor</string>
 </resources>


### PR DESCRIPTION
Seems the "Disable Tor to make calls" isn't enough.

This shows a toast stating that A/V is disabled when enabling Tor or when setting an .onion hostname.