### PR TITLE
Always show Quote as last action

### DIFF
--- a/src/main/res/menu/message_context.xml
+++ b/src/main/res/menu/message_context.xml
@@ -20,10 +20,6 @@
         android:id="@+id/copy_link"
         android:title="@string/copy_link"
         android:visible="false" />
-    <item
-        android:id="@+id/quote_message"
-        android:title="@string/quote"
-        android:visible="false" />
 
     <item
         android:id="@+id/retry_decryption"
@@ -32,6 +28,10 @@
     <item
         android:id="@+id/correct_message"
         android:title="@string/correct_message"
+        android:visible="false" />
+    <item
+        android:id="@+id/quote_message"
+        android:title="@string/quote"
         android:visible="false" />
     <item
         android:id="@+id/copy_url"


### PR DESCRIPTION
Two ideas:
* muscle memory - there's a lot more quoting in general than message correction so fingers want to touch the last entry
* UX design - actions used more often on top, here Correction is higher since it's used more often for self messages than Quote