### PR TITLE
Feature: nested quotes

### DIFF
--- a/src/main/java/eu/siacs/conversations/Config.java
+++ b/src/main/java/eu/siacs/conversations/Config.java
@@ -205,5 +205,5 @@ public final class Config {
     // How deep nested quotes should be displayed. '2' means one quote nested in another.
     public static final int QUOTE_MAX_DEPTH = 3;
     // How deep nested quotes should be created on quoting a message.
-    public static final int QUOTING_MAX_DEPTH = QUOTE_MAX_DEPTH - 1;
+    public static final int QUOTING_MAX_DEPTH = QUOTE_MAX_DEPTH;
 }

--- a/src/main/java/eu/siacs/conversations/Config.java
+++ b/src/main/java/eu/siacs/conversations/Config.java
@@ -202,6 +202,8 @@ public final class Config {
         public final static int LOCATION_FIX_SIGNIFICANT_TIME_DELTA = 1000 * 60 * 2; // ms
     }
 
-    // How deep nested quotes should become. '2' means one quote nested in another.
+    // How deep nested quotes should be displayed. '2' means one quote nested in another.
     public static final int QUOTE_MAX_DEPTH = 3;
+    // How deep nested quotes should be created on quoting a message.
+    public static final int QUOTING_MAX_DEPTH = QUOTE_MAX_DEPTH - 1;
 }

--- a/src/main/java/eu/siacs/conversations/Config.java
+++ b/src/main/java/eu/siacs/conversations/Config.java
@@ -203,7 +203,7 @@ public final class Config {
     }
 
     // How deep nested quotes should be displayed. '2' means one quote nested in another.
-    public static final int QUOTE_MAX_DEPTH = 3;
+    public static final int QUOTE_MAX_DEPTH = 7;
     // How deep nested quotes should be created on quoting a message.
-    public static final int QUOTING_MAX_DEPTH = QUOTE_MAX_DEPTH;
+    public static final int QUOTING_MAX_DEPTH = 1;
 }

--- a/src/main/java/eu/siacs/conversations/Config.java
+++ b/src/main/java/eu/siacs/conversations/Config.java
@@ -201,4 +201,7 @@ public final class Config {
         public final static float LOCATION_FIX_SPACE_DELTA = 10; // m
         public final static int LOCATION_FIX_SIGNIFICANT_TIME_DELTA = 1000 * 60 * 2; // ms
     }
+
+    // How deep nested quotes should become. '2' means one quote nested in another.
+    public static final int QUOTE_MAX_DEPTH = 3;
 }

--- a/src/main/java/eu/siacs/conversations/ui/adapter/MessageAdapter.java
+++ b/src/main/java/eu/siacs/conversations/ui/adapter/MessageAdapter.java
@@ -371,9 +371,8 @@ public class MessageAdapter extends ArrayAdapter<Message> {
                 if (lineStart == -1) {
                     if (previous == '\n') {
                         if (
-                                (QuoteHelper.isPositionQuoteStart(body, i)
-                                        || (current == '\u00bb' && !UIHelper.isPositionFollowedByQuote(body, i)
-                                ))) {
+                                QuoteHelper.isPositionQuoteStart(body, i)
+                        ) {
                             // Line start with quote
                             lineStart = i;
                             if (quoteStart == -1) quoteStart = i;

--- a/src/main/java/eu/siacs/conversations/ui/adapter/MessageAdapter.java
+++ b/src/main/java/eu/siacs/conversations/ui/adapter/MessageAdapter.java
@@ -381,7 +381,6 @@ public class MessageAdapter extends ArrayAdapter<Message> {
                             // Line start without quote, apply spans there
                             applyQuoteSpan(body, quoteStart, i - 1, darkBackground);
                             quoteStart = -1;
-                            quoteDepth++;
                         }
                     }
                 } else {
@@ -406,8 +405,8 @@ public class MessageAdapter extends ArrayAdapter<Message> {
             if (quoteStart >= 0) {
                 // Apply spans to finishing open quote
                 applyQuoteSpan(body, quoteStart, body.length(), darkBackground);
-                quoteDepth++;
             }
+            quoteDepth++;
         }
         return startsWithQuote;
     }

--- a/src/main/java/eu/siacs/conversations/ui/util/QuoteHelper.java
+++ b/src/main/java/eu/siacs/conversations/ui/util/QuoteHelper.java
@@ -5,8 +5,32 @@ import eu.siacs.conversations.utils.UIHelper;
 
 public class QuoteHelper {
 
+
+    public static final char QUOTE_CHAR = '>';
+    public static final char QUOTE_END_CHAR = '<'; // used for one check, not for actual quoting
+    public static final char QUOTE_ALT_CHAR = '»';
+    public static final char QUOTE_ALT_END_CHAR = '«';
+
     public static boolean isPositionQuoteCharacter(CharSequence body, int pos){
-        return body.charAt(pos) == '>';
+        // second part of logical check actually goes against the logic indicated in the method name, since it also checks for context
+        // but it's very useful
+        return body.charAt(pos) == QUOTE_CHAR || isPositionAltQuoteStart(body, pos);
+    }
+
+    public static boolean isPositionQuoteEndCharacter(CharSequence body, int pos){
+        return body.charAt(pos) == QUOTE_END_CHAR;
+    }
+
+    public static boolean isPositionAltQuoteCharacter (CharSequence body, int pos){
+        return body.charAt(pos) == QUOTE_ALT_CHAR;
+    }
+
+    public static boolean isPositionAltQuoteEndCharacter(CharSequence body, int pos){
+        return body.charAt(pos) == QUOTE_ALT_END_CHAR;
+    }
+
+    public static boolean isPositionAltQuoteStart(CharSequence body, int pos){
+        return isPositionAltQuoteCharacter(body, pos) && !isPositionFollowedByAltQuoteEnd(body, pos);
     }
 
     public static boolean isPositionFollowedByQuoteChar(CharSequence body, int pos) {
@@ -19,16 +43,34 @@ public class QuoteHelper {
     }
 
     public static boolean isPositionQuoteStart (CharSequence body, int pos){
-        return isPositionQuoteCharacter(body, pos)
+        return (isPositionQuoteCharacter(body, pos)
                 && isPositionPrecededByPrequote(body, pos)
-                && (UIHelper.isPositionFollowedByWhitespace(body, pos)
-                    || isPositionFollowedByQuoteChar(body, pos));
+                && (UIHelper.isPositionFollowedByQuoteableCharacter(body, pos)
+                    || isPositionFollowedByQuoteChar(body, pos)));
     }
 
     public static boolean bodyContainsQuoteStart (CharSequence body){
        for (int i = 0; i < body.length(); i++){
             if (isPositionQuoteStart(body, i)){
                 return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean isPositionFollowedByAltQuoteEnd(CharSequence body, int pos) {
+        if (body.length() <= pos + 1 || Character.isWhitespace(body.charAt(pos + 1))) {
+            return false;
+        }
+        boolean previousWasWhitespace = false;
+        for (int i = pos + 1; i < body.length(); i++) {
+            char c = body.charAt(i);
+            if (c == '\n' || isPositionAltQuoteCharacter(body, i)) {
+                return false;
+            } else if (isPositionAltQuoteEndCharacter(body, i) && !previousWasWhitespace) {
+                return true;
+            } else {
+                previousWasWhitespace = Character.isWhitespace(c);
             }
         }
         return false;
@@ -47,5 +89,14 @@ public class QuoteHelper {
             }
         }
         return false;
+    }
+
+    public static String replaceAltQuoteCharsInText(String text){
+        for (int i = 0; i < text.length(); i++){
+            if (isPositionAltQuoteStart(text, i)){
+                text = text.substring(0, i) + QUOTE_CHAR + text.substring(i + 1);
+            }
+        }
+        return text;
     }
 }

--- a/src/main/java/eu/siacs/conversations/ui/util/QuoteHelper.java
+++ b/src/main/java/eu/siacs/conversations/ui/util/QuoteHelper.java
@@ -1,5 +1,6 @@
 package eu.siacs.conversations.ui.util;
 
+import eu.siacs.conversations.Config;
 import eu.siacs.conversations.utils.UIHelper;
 
 public class QuoteHelper {
@@ -32,20 +33,19 @@ public class QuoteHelper {
         }
         return false;
     }
-    /*public static int getQuoteColors(XmppActivity activity, boolean darkBackground, int quoteDepth){
-        int[] colorsLight = R.style.ConversationsTheme_Dark;
-        int[] colorsDark = Config.QUOTE_COLOR_ARRAY_DARK;
 
-       Collections.rotate(Collections.singletonList(colorsLight), quoteDepth);
-       Collections.rotate(Collections.singletonList(colorsDark), quoteDepth);
-
-       Arrays.stream(colorsLight).toArray();
-
-        int quoteColors =  darkBackground ? ContextCompat.getColor(activity, colorsLight[quoteDepth-1])
-                : ContextCompat.getColor(activity, colorsDark[quoteDepth-1]);
-
-        Collections.rotate
-
-        return quoteColors;
-    };*/
+    public static boolean isNestedTooDeeply (CharSequence line){
+        if (isPositionQuoteCharacter(line, 0)) {
+            int nestingDepth = 1;
+            for (int i = 1; i < line.length(); i++) {
+                if (isPositionQuoteCharacter(line, i)) {
+                    nestingDepth++;
+                }
+                if (nestingDepth > (Config.QUOTING_MAX_DEPTH)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
 }

--- a/src/main/java/eu/siacs/conversations/ui/util/QuoteHelper.java
+++ b/src/main/java/eu/siacs/conversations/ui/util/QuoteHelper.java
@@ -1,0 +1,51 @@
+package eu.siacs.conversations.ui.util;
+
+import eu.siacs.conversations.utils.UIHelper;
+
+public class QuoteHelper {
+
+    public static boolean isPositionQuoteCharacter(CharSequence body, int pos){
+        return body.charAt(pos) == '>';
+    }
+
+    public static boolean isPositionFollowedByQuoteChar(CharSequence body, int pos) {
+        return body.length() > pos + 1 && isPositionQuoteCharacter(body, pos +1 );
+    }
+
+    // 'Prequote' means anything we require or can accept in front of a QuoteChar
+    public static boolean isPositionPrecededByPrequote(CharSequence body, int pos){
+        return UIHelper.isPositionPrecededByLineStart(body, pos);
+    }
+
+    public static boolean isPositionQuoteStart (CharSequence body, int pos){
+        return isPositionQuoteCharacter(body, pos)
+                && isPositionPrecededByPrequote(body, pos)
+                && (UIHelper.isPositionFollowedByWhitespace(body, pos)
+                    || isPositionFollowedByQuoteChar(body, pos));
+    }
+
+    public static boolean bodyContainsQuoteStart (CharSequence body){
+       for (int i = 0; i < body.length(); i++){
+            if (isPositionQuoteStart(body, i)){
+                return true;
+            }
+        }
+        return false;
+    }
+    /*public static int getQuoteColors(XmppActivity activity, boolean darkBackground, int quoteDepth){
+        int[] colorsLight = R.style.ConversationsTheme_Dark;
+        int[] colorsDark = Config.QUOTE_COLOR_ARRAY_DARK;
+
+       Collections.rotate(Collections.singletonList(colorsLight), quoteDepth);
+       Collections.rotate(Collections.singletonList(colorsDark), quoteDepth);
+
+       Arrays.stream(colorsLight).toArray();
+
+        int quoteColors =  darkBackground ? ContextCompat.getColor(activity, colorsLight[quoteDepth-1])
+                : ContextCompat.getColor(activity, colorsDark[quoteDepth-1]);
+
+        Collections.rotate
+
+        return quoteColors;
+    };*/
+}

--- a/src/main/java/eu/siacs/conversations/ui/util/QuoteHelper.java
+++ b/src/main/java/eu/siacs/conversations/ui/util/QuoteHelper.java
@@ -41,7 +41,7 @@ public class QuoteHelper {
                 if (isPositionQuoteCharacter(line, i)) {
                     nestingDepth++;
                 }
-                if (nestingDepth > (Config.QUOTING_MAX_DEPTH)) {
+                if (nestingDepth > (Config.QUOTING_MAX_DEPTH - 1)) {
                     return true;
                 }
             }

--- a/src/main/java/eu/siacs/conversations/ui/widget/EditMessage.java
+++ b/src/main/java/eu/siacs/conversations/ui/widget/EditMessage.java
@@ -24,6 +24,7 @@ import java.util.concurrent.Executors;
 
 import eu.siacs.conversations.Config;
 import eu.siacs.conversations.R;
+import eu.siacs.conversations.ui.util.QuoteHelper;
 
 public class EditMessage extends EmojiWrapperEditText {
 
@@ -142,7 +143,8 @@ public class EditMessage extends EmojiWrapperEditText {
     }
 
     public void insertAsQuote(String text) {
-        text = text.replaceAll("(\n *){2,}", "\n").replaceAll("(^|\n)>", "$1>>").replaceAll("(^|\n)([^>])", "$1> $2").replaceAll("\n$", "");
+        text = QuoteHelper.replaceAltQuoteCharsInText(text);
+        text = text.replaceAll("(\n *){2,}", "\n").replaceAll("(^|\n)(" + QuoteHelper.QUOTE_CHAR + ")", "$1$2$2").replaceAll("(^|\n)([^>" + QuoteHelper.QUOTE_CHAR + "])", "$1> $2").replaceAll("\n$", "");
         Editable editable = getEditableText();
         int position = getSelectionEnd();
         if (position == -1) position = editable.length();

--- a/src/main/java/eu/siacs/conversations/ui/widget/EditMessage.java
+++ b/src/main/java/eu/siacs/conversations/ui/widget/EditMessage.java
@@ -144,7 +144,7 @@ public class EditMessage extends EmojiWrapperEditText {
 
     public void insertAsQuote(String text) {
         text = QuoteHelper.replaceAltQuoteCharsInText(text);
-        text = text.replaceAll("(\n *){2,}", "\n").replaceAll("(^|\n)(" + QuoteHelper.QUOTE_CHAR + ")", "$1$2$2").replaceAll("(^|\n)([^>" + QuoteHelper.QUOTE_CHAR + "])", "$1> $2").replaceAll("\n$", "");
+        text = text.replaceAll("(\n *){2,}", "\n").replaceAll("(^|\n)(" + QuoteHelper.QUOTE_CHAR + ")", "$1$2$2").replaceAll("(^|\n)([^" + QuoteHelper.QUOTE_CHAR + "])", "$1> $2").replaceAll("\n$", "");
         Editable editable = getEditableText();
         int position = getSelectionEnd();
         if (position == -1) position = editable.length();

--- a/src/main/java/eu/siacs/conversations/ui/widget/EditMessage.java
+++ b/src/main/java/eu/siacs/conversations/ui/widget/EditMessage.java
@@ -142,7 +142,7 @@ public class EditMessage extends EmojiWrapperEditText {
     }
 
     public void insertAsQuote(String text) {
-        text = text.replaceAll("(\n *){2,}", "\n").replaceAll("(^|\n)", "$1> ").replaceAll("\n$", "");
+        text = text.replaceAll("(\n *){2,}", "\n").replaceAll("(^|\n)>", "$1>>").replaceAll("(^|\n)([^>])", "$1> $2").replaceAll("\n$", "");
         Editable editable = getEditableText();
         int position = getSelectionEnd();
         if (position == -1) position = editable.length();

--- a/src/main/java/eu/siacs/conversations/utils/MessageUtils.java
+++ b/src/main/java/eu/siacs/conversations/utils/MessageUtils.java
@@ -70,8 +70,7 @@ public class MessageUtils {
                 continue;
             }
             final char c = line.charAt(0);
-            if (QuoteHelper.isNestedTooDeeply(line)
-                    || (c == '\u00bb' && !UIHelper.isPositionFollowedByQuote(line, 0))) {
+            if (QuoteHelper.isNestedTooDeeply(line)) {
                 continue;
             }
             if (builder.length() != 0) {

--- a/src/main/java/eu/siacs/conversations/utils/MessageUtils.java
+++ b/src/main/java/eu/siacs/conversations/utils/MessageUtils.java
@@ -39,6 +39,7 @@ import eu.siacs.conversations.entities.Conversational;
 import eu.siacs.conversations.entities.Message;
 import eu.siacs.conversations.http.AesGcmURL;
 import eu.siacs.conversations.http.URL;
+import eu.siacs.conversations.ui.util.QuoteHelper;
 
 public class MessageUtils {
 
@@ -69,7 +70,7 @@ public class MessageUtils {
                 continue;
             }
             final char c = line.charAt(0);
-            if (c == '>' && UIHelper.isPositionFollowedByQuoteableCharacter(line, 0)
+            if (QuoteHelper.isNestedTooDeeply(line)
                     || (c == '\u00bb' && !UIHelper.isPositionFollowedByQuote(line, 0))) {
                 continue;
             }

--- a/src/main/java/eu/siacs/conversations/utils/UIHelper.java
+++ b/src/main/java/eu/siacs/conversations/utils/UIHelper.java
@@ -372,6 +372,34 @@ public class UIHelper {
         return input.length() > 256 ? StylingHelper.subSequence(input, 0, 256) : input;
     }
 
+    public static boolean isPositionFollowedByWhitespace(CharSequence body, int pos){
+        return Character.isWhitespace(body.charAt(pos + 1));
+    }
+
+    public static boolean isPositionPrecededByWhitespace(CharSequence body, int pos){
+        return Character.isWhitespace(body.charAt(pos -1 ));
+    }
+
+    public static boolean isPositionPrecededByBodyStart(CharSequence body, int pos){
+        // true if not a single linebreak before current position
+        for (int i = pos - 1; i >= 0; i--){
+            if (body.charAt(i) != ' '){
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static boolean isPositionPrecededByLineStart(CharSequence body, int pos){
+        if (isPositionPrecededByBodyStart(body, pos)){
+            return true;
+        }
+        if (body.charAt(pos - 1) == '\n'){
+            return true;
+        }
+        return false;
+    }
+
     public static boolean isPositionFollowedByQuoteableCharacter(CharSequence body, int pos) {
         return !isPositionFollowedByNumber(body, pos)
                 && !isPositionFollowedByEmoticon(body, pos)

--- a/src/main/java/eu/siacs/conversations/utils/UIHelper.java
+++ b/src/main/java/eu/siacs/conversations/utils/UIHelper.java
@@ -32,6 +32,7 @@ import eu.siacs.conversations.entities.Presence;
 import eu.siacs.conversations.entities.RtpSessionStatus;
 import eu.siacs.conversations.entities.Transferable;
 import eu.siacs.conversations.services.ExportBackupService;
+import eu.siacs.conversations.ui.util.QuoteHelper;
 import eu.siacs.conversations.xmpp.Jid;
 
 public class UIHelper {
@@ -328,7 +329,7 @@ public class UIHelper {
                             continue;
                         }
                         char first = l.charAt(0);
-                        if ((first != '>' || !isPositionFollowedByQuoteableCharacter(l, 0)) && first != '\u00bb') {
+                        if ((!QuoteHelper.isPositionQuoteStart(l, 0)) && first != '\u00bb') {
                             CharSequence line = CharSequenceUtils.trim(l);
                             if (line.length() == 0) {
                                 continue;

--- a/src/main/java/eu/siacs/conversations/utils/UIHelper.java
+++ b/src/main/java/eu/siacs/conversations/utils/UIHelper.java
@@ -329,7 +329,7 @@ public class UIHelper {
                             continue;
                         }
                         char first = l.charAt(0);
-                        if ((!QuoteHelper.isPositionQuoteStart(l, 0)) && first != '\u00bb') {
+                        if ((!QuoteHelper.isPositionQuoteStart(l, 0))) {
                             CharSequence line = CharSequenceUtils.trim(l);
                             if (line.length() == 0) {
                                 continue;
@@ -373,14 +373,6 @@ public class UIHelper {
         return input.length() > 256 ? StylingHelper.subSequence(input, 0, 256) : input;
     }
 
-    public static boolean isPositionFollowedByWhitespace(CharSequence body, int pos){
-        return Character.isWhitespace(body.charAt(pos + 1));
-    }
-
-    public static boolean isPositionPrecededByWhitespace(CharSequence body, int pos){
-        return Character.isWhitespace(body.charAt(pos -1 ));
-    }
-
     public static boolean isPositionPrecededByBodyStart(CharSequence body, int pos){
         // true if not a single linebreak before current position
         for (int i = pos - 1; i >= 0; i--){
@@ -395,10 +387,7 @@ public class UIHelper {
         if (isPositionPrecededByBodyStart(body, pos)){
             return true;
         }
-        if (body.charAt(pos - 1) == '\n'){
-            return true;
-        }
-        return false;
+        return body.charAt(pos - 1) == '\n';
     }
 
     public static boolean isPositionFollowedByQuoteableCharacter(CharSequence body, int pos) {
@@ -442,26 +431,8 @@ public class UIHelper {
             final char c = body.charAt(i);
             if (Character.isWhitespace(c)) {
                 return false;
-            } else if (c == '<' || c == '>') {
+            } else if (QuoteHelper.isPositionQuoteCharacter(body, pos) || QuoteHelper.isPositionQuoteEndCharacter(body, pos)) {
                 return body.length() == i + 1 || Character.isWhitespace(body.charAt(i + 1));
-            }
-        }
-        return false;
-    }
-
-    public static boolean isPositionFollowedByQuote(CharSequence body, int pos) {
-        if (body.length() <= pos + 1 || Character.isWhitespace(body.charAt(pos + 1))) {
-            return false;
-        }
-        boolean previousWasWhitespace = false;
-        for (int i = pos + 1; i < body.length(); i++) {
-            char c = body.charAt(i);
-            if (c == '\n' || c == '»') {
-                return false;
-            } else if (c == '«' && !previousWasWhitespace) {
-                return true;
-            } else {
-                previousWasWhitespace = Character.isWhitespace(c);
             }
         }
         return false;


### PR DESCRIPTION
## What
Answering feature request #3981 for nested quotations in compliance with XEP-0393. It basically loops over the body as long as it finds QuoteStarts and reapplies the QuoteSpan. On quoting quotes, it deletes any quotes that are nested too deeply. Also, on quoting quotes that contain French quotes, it replaces those French quotes with XEP-0393 quotes.

<a href="https://user-images.githubusercontent.com/32270710/130408656-6520b809-84af-457d-b750-4bbfa8491f51.png"><img src="https://user-images.githubusercontent.com/32270710/130408656-6520b809-84af-457d-b750-4bbfa8491f51.png" width="200" /></a>

## Config
Nesting depth is limited by Config.QUOTE_MAX_DEPTH (currently 7), to limit it based on dev experience w.r.t. performance and aesthetics. Depth of quoting nested quotes is limited by Config.QUOTING_MAX_DEPTH and currently set to 1.

Quoting depth should be limited to 1 for the first release, since reading early updaters' nested quote would turn into bad UX for late updaters (i.e. first release: ability to display nested quotes; second release: ability to create nested quotes). Afterwards, quoting depth can be increased to 2 or 3, but more would add little value in standard scenarios.

## Further ideas
* The different depths could be distinguished by colour. For this purpose, the QuoteDepth could be handed over to the QuoteSpan methods which would then iterorate over a colour array provided by the theme.
* Alternatively, different depths could be distinguished by geometry (dashed, dotted, …) and transparency (suggestions from Conversations muc).
* Depth of displayed quotes could be automagically adjusted to screen size (suggestion from Conversation muc)
* Quotes could be preceded by author of original message for better overview (suggestion from Conversations muc).