### PR TITLE
Simple media quotes

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
+++ b/src/main/java/eu/siacs/conversations/ui/ConversationFragment.java
@@ -1266,9 +1266,12 @@ public class ConversationFragment extends XmppFragment
     }
 
     private void quoteMedia(Message message) {
+        Message.FileParams params = message.getFileParams();
+        String filesize = params.size != null ? UIHelper.filesizeToString(params.size) : null;
+
         String text =
-                MimeUtils.getMimeTypeEmoji(getActivity(), message.getMimeType())
-                + " _"
+                MimeUtils.getMimeTypeEmoji(getActivity(), message.getMimeType()) + " _"
+                + filesize + "; "
                 + UIHelper.readableTimeDifference(getActivity(), message.getTimeSent(), true, true)
                 + "_";
         quoteText(text);

--- a/src/main/java/eu/siacs/conversations/ui/util/QuoteHelper.java
+++ b/src/main/java/eu/siacs/conversations/ui/util/QuoteHelper.java
@@ -1,6 +1,8 @@
 package eu.siacs.conversations.ui.util;
 
 import eu.siacs.conversations.Config;
+import eu.siacs.conversations.entities.Message;
+import eu.siacs.conversations.utils.MessageUtils;
 import eu.siacs.conversations.utils.UIHelper;
 
 public class QuoteHelper {
@@ -102,5 +104,15 @@ public class QuoteHelper {
             }
         }
         return text;
+    }
+
+    public static boolean isMessageQuoteable(Message m){
+        if (m.isTypeText() && MessageUtils.prepareQuote(m).length() > 0) {
+            return true;
+        }
+        if (m.isFileOrImage()){
+            return true;
+        }
+        return false;
     }
 }

--- a/src/main/java/eu/siacs/conversations/utils/MimeUtils.java
+++ b/src/main/java/eu/siacs/conversations/utils/MimeUtils.java
@@ -28,12 +28,14 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
 import eu.siacs.conversations.Config;
+import eu.siacs.conversations.R;
 import eu.siacs.conversations.entities.Transferable;
 import eu.siacs.conversations.services.ExportBackupService;
 
@@ -413,6 +415,16 @@ public final class MimeUtils {
         applyOverrides();
     }
 
+    private static final List<String> DOCUMENT_MIMES = Arrays.asList(
+            "application/pdf",
+            "application/vnd.oasis.opendocument.text",
+            "application/msword",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "text/x-tex",
+            "text/plain"
+    );
+
+
     private static void add(String mimeType, String extension) {
         // If we have an existing x -> y mapping, we do not want to
         // override it with another mapping x -> y2.
@@ -633,5 +645,33 @@ public final class MimeUtils {
         } else {
             return input;
         }
+    }
+
+    public static String getLocalisedMimeType(Context context, String mime){
+        int lm;
+        if (mime == null) {
+            lm = R.string.unknown;
+        } else if (mime.startsWith("audio/")) {
+            lm = R.string.audio;
+        } else if (mime.equals("text/calendar") || (mime.equals("text/x-vcalendar"))) {
+            lm = R.string.calendar_item;
+        } else if (mime.equals("text/x-vcard")) {
+            lm = R.string.contact;
+        } else if (mime.equals("application/vnd.android.package-archive")) {
+            lm = R.string.app;
+        } else if (mime.equals("application/zip") || mime.equals("application/rar")) {
+            lm = R.string.archive;
+        } else if (mime.equals("application/epub+zip") || mime.equals("application/vnd.amazon.mobi8-ebook")) {
+            lm = R.string.ebook;
+        } else if (mime.equals(ExportBackupService.MIME_TYPE)) {
+            lm = R.string.backup;
+        } else if (DOCUMENT_MIMES.contains(mime)) {
+            lm = R.string.document;
+        } else if (mime.startsWith("image/")) {
+            lm = R.string.image;
+        } else {
+            lm = R.string.file;
+        }
+        return context.getString(lm).substring(0, 1).toUpperCase() + context.getString(lm).substring(1).toLowerCase();
     }
 }

--- a/src/main/java/eu/siacs/conversations/utils/MimeUtils.java
+++ b/src/main/java/eu/siacs/conversations/utils/MimeUtils.java
@@ -647,31 +647,33 @@ public final class MimeUtils {
         }
     }
 
-    public static String getLocalisedMimeType(Context context, String mime){
-        int lm;
+    public static String getMimeTypeEmoji(Context context, String mime){
+        String lm;
         if (mime == null) {
-            lm = R.string.unknown;
+            lm = context.getString(R.string.unknown);
         } else if (mime.startsWith("audio/")) {
-            lm = R.string.audio;
+            lm = "\uD83C\uDF99"; // studio microphone emoji
         } else if (mime.equals("text/calendar") || (mime.equals("text/x-vcalendar"))) {
-            lm = R.string.calendar_item;
+            lm = "\uD83D\uDCC6"; // tear-off calendar emoji
         } else if (mime.equals("text/x-vcard")) {
-            lm = R.string.contact;
+            lm = "\uD83D\uDC64"; // silhouette emoji
         } else if (mime.equals("application/vnd.android.package-archive")) {
-            lm = R.string.app;
+            lm = "\uD83D\uDCF1"; // cell phone emoji
         } else if (mime.equals("application/zip") || mime.equals("application/rar")) {
-            lm = R.string.archive;
+            lm = "\uD83D\uDDC4️"; // filing cabinet emoji
         } else if (mime.equals("application/epub+zip") || mime.equals("application/vnd.amazon.mobi8-ebook")) {
-            lm = R.string.ebook;
+            lm = "\uD83D\uDCD6"; // open book emoji
         } else if (mime.equals(ExportBackupService.MIME_TYPE)) {
-            lm = R.string.backup;
+            lm = "\uD83D\uDCBE"; // diskette emoji
         } else if (DOCUMENT_MIMES.contains(mime)) {
-            lm = R.string.document;
+            lm = "\uD83D\uDCC4"; // page emoji
         } else if (mime.startsWith("image/")) {
-            lm = R.string.image;
+            lm = "\uD83D\uDDBC️"; // painting emoji
+        } else if (mime.startsWith("video/")) {
+            lm = "\uD83C\uDFAC"; // clapper board emoji
         } else {
-            lm = R.string.file;
+            lm = "\uD83D\uDCC4"; // page emoji
         }
-        return context.getString(lm).substring(0, 1).toUpperCase() + context.getString(lm).substring(1).toLowerCase();
+        return lm;
     }
 }

--- a/src/main/java/eu/siacs/conversations/utils/UIHelper.java
+++ b/src/main/java/eu/siacs/conversations/utils/UIHelper.java
@@ -17,6 +17,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+import java.util.TimeZone;
 
 import eu.siacs.conversations.Config;
 import eu.siacs.conversations.R;
@@ -137,19 +138,22 @@ public class UIHelper {
             | DateUtils.FORMAT_ABBREV_ALL | DateUtils.FORMAT_SHOW_DATE;
 
     public static String readableTimeDifference(Context context, long time) {
-        return readableTimeDifference(context, time, false);
+        return readableTimeDifference(context, time, false, false);
     }
 
     public static String readableTimeDifferenceFull(Context context, long time) {
-        return readableTimeDifference(context, time, true);
+        return readableTimeDifference(context, time, true, false);
     }
 
-    private static String readableTimeDifference(Context context, long time,
-                                                 boolean fullDate) {
+    public static String readableTimeDifference(Context context, long time,
+                                                 boolean fullDate, boolean printTz) {
         if (time == 0) {
             return context.getString(R.string.just_now);
         }
         Date date = new Date(time);
+        TimeZone tz = TimeZone.getDefault();
+        String tzString = "(" + tz.getDisplayName(tz.inDaylightTime(date),
+                TimeZone.SHORT, Locale.UK) + ")";
         long difference = (System.currentTimeMillis() - time) / 1000;
         if (difference < 60) {
             return context.getString(R.string.just_now);
@@ -159,13 +163,15 @@ public class UIHelper {
             return context.getString(R.string.minutes_ago, Math.round(difference / 60.0));
         } else if (today(date)) {
             java.text.DateFormat df = DateFormat.getTimeFormat(context);
-            return df.format(date);
+            return printTz ? df.format(date) + " " + tzString : df.format(date);
         } else {
             if (fullDate) {
-                return DateUtils.formatDateTime(context, date.getTime(),
+                return printTz ? DateUtils.formatDateTime(context, date.getTime(),
+                        FULL_DATE_FLAGS) + " " + tzString :  DateUtils.formatDateTime(context, date.getTime(),
                         FULL_DATE_FLAGS);
             } else {
-                return DateUtils.formatDateTime(context, date.getTime(),
+                return printTz ? DateUtils.formatDateTime(context, date.getTime(),
+                        SHORT_DATE_FLAGS) + " " + tzString : DateUtils.formatDateTime(context, date.getTime(),
                         SHORT_DATE_FLAGS);
             }
         }

--- a/src/main/res/menu/message_context.xml
+++ b/src/main/res/menu/message_context.xml
@@ -21,18 +21,10 @@
         android:title="@string/copy_link"
         android:visible="false" />
     <item
-        android:id="@+id/quote_message"
-        android:title="@string/quote"
-        android:visible="false" />
-
-    <item
         android:id="@+id/retry_decryption"
         android:title="@string/retry_decryption"
         android:visible="false" />
-    <item
-        android:id="@+id/correct_message"
-        android:title="@string/correct_message"
-        android:visible="false" />
+
     <item
         android:id="@+id/copy_url"
         android:title="@string/copy_original_url"
@@ -56,5 +48,13 @@
     <item
         android:id="@+id/delete_file"
         android:title="@string/delete_x_file"
+        android:visible="false" />
+    <item
+        android:id="@+id/quote_message"
+        android:title="@string/quote"
+        android:visible="false" />
+    <item
+        android:id="@+id/correct_message"
+        android:title="@string/correct_message"
         android:visible="false" />
 </menu>


### PR DESCRIPTION
I waited a little with this PR, since I'm well aware that it is not a beautiful solution and that there is a better solution planned with The Rewrite. However, it has proven itself very useful in the last weeks (even for non tech-savvy folks) and it is available *now*.

## What
The PR adds the "quote" option to media messages. If used, it creates a simple '>' quote that indicates the media type and the time it was sent. The media type is indicated through an Emoji (less strings to translate). The time is localised with readableTimeDifference to provide a consistent experience.

It is immediately compatible with other clients and nested quotes. If rich quotes are introduced, it could still remain as fallback.

<a href="https://user-images.githubusercontent.com/32270710/139710535-ee5ab3ee-adac-4296-949a-2690a2f0aa31.png"><img width="50%" src="https://user-images.githubusercontent.com/32270710/139710535-ee5ab3ee-adac-4296-949a-2690a2f0aa31.png" /></a>

## Considerations
1. Especially in MUCs, it might accidentally leak the locale. I think that's negligible, since the user sees the message before sending it (if it should become the fallback in rich media quotes, the locale is no longer needed for consistency and should be set to UTC to avoid accidental invisible leakage invisible for the user).
2. What if two messages of the same media type are sent in the same minute? Seems to be an edge case, I didn't experience it in my daily usage the last weeks.

Again, thanks to my Tech Talk folks for suggesting as well as testing it. :)

## Update
W.r.t. the second consideration, I added filesize to the quote. Hope this improves discernability.