### PR TITLE
Add handling of status code 333

### DIFF
--- a/src/main/java/eu/siacs/conversations/entities/MucOptions.java
+++ b/src/main/java/eu/siacs/conversations/entities/MucOptions.java
@@ -34,6 +34,7 @@ public class MucOptions {
     public static final String STATUS_CODE_AFFILIATION_CHANGE = "321";
     public static final String STATUS_CODE_LOST_MEMBERSHIP = "322";
     public static final String STATUS_CODE_SHUTDOWN = "332";
+    public static final String STATUS_CODE_TECHNICAL_REASONS = "333";
     private final Set<User> users = new HashSet<>();
     private final Conversation conversation;
     public OnRenameListener onRenameListener = null;

--- a/src/main/java/eu/siacs/conversations/parser/PresenceParser.java
+++ b/src/main/java/eu/siacs/conversations/parser/PresenceParser.java
@@ -143,7 +143,9 @@ public class PresenceParser extends AbstractParser implements
 				} else if (codes.contains(MucOptions.STATUS_CODE_SHUTDOWN) && fullJidMatches) {
 					mucOptions.setError(MucOptions.Error.SHUTDOWN);
 				} else if (codes.contains(MucOptions.STATUS_CODE_SELF_PRESENCE)) {
-					if (codes.contains(MucOptions.STATUS_CODE_KICKED)) {
+					if (codes.contains(MucOptions.STATUS_CODE_TECHNICAL_REASONS)) {
+						mucOptions.setError(MucOptions.Error.UNKNOWN);
+					} else if (codes.contains(MucOptions.STATUS_CODE_KICKED)) {
 						mucOptions.setError(MucOptions.Error.KICKED);
 					} else if (codes.contains(MucOptions.STATUS_CODE_BANNED)) {
 						mucOptions.setError(MucOptions.Error.BANNED);


### PR DESCRIPTION
This is used when something goes wrong with a MUC, e.g. a connection error made the MUC kick you out. In this case you generally want to try to rejoin. Showing a toast with an option to do so seems like a sensible first step.

I recently made a Prosody [plugin](https://modules.prosody.im/mod_ping_muc.html) that tries to check if you are still connected after s2s connections to a MUC have been lost, communicating to clients if the answer is negative. Telling the user that they were kicked isn't really accurate in this case and the more accurate status code `333` was not supported yet, so here goes.

Currently reusing the same `conference_unknown_error` string since it is close enough and I couldn't think of a good and compact message explaining it better.