### PR TITLE
Enable WebRTC-BindUsingInterfaceName/Enabled/

### DIFF
--- a/src/main/java/eu/siacs/conversations/xmpp/jingle/WebRTCWrapper.java
+++ b/src/main/java/eu/siacs/conversations/xmpp/jingle/WebRTCWrapper.java
@@ -233,7 +233,9 @@ public class WebRTCWrapper {
     public void setup(final XmppConnectionService service, final AppRTCAudioManager.SpeakerPhonePreference speakerPhonePreference) throws InitializationException {
         try {
             PeerConnectionFactory.initialize(
-                    PeerConnectionFactory.InitializationOptions.builder(service).createInitializationOptions()
+                    PeerConnectionFactory.InitializationOptions.builder(service)
+                    .setFieldTrials("WebRTC-BindUsingInterfaceName/Enabled/")
+                    .createInitializationOptions()
             );
         } catch (final UnsatisfiedLinkError e) {
             throw new InitializationException("Unable to initialize PeerConnectionFactory", e);


### PR DESCRIPTION
This makes 464XLAT networks (such as T-Mobile LTE) work.

https://bugs.chromium.org/p/webrtc/issues/detail?id=10707