### PR TITLE
Close socks5 connection when done sending data

### DIFF
--- a/src/main/java/eu/siacs/conversations/xmpp/jingle/JingleFileTransferConnection.java
+++ b/src/main/java/eu/siacs/conversations/xmpp/jingle/JingleFileTransferConnection.java
@@ -151,6 +151,7 @@ public class JingleFileTransferConnection extends AbstractJingleConnection imple
                 if (message.getEncryption() == Message.ENCRYPTION_PGP || message.getEncryption() == Message.ENCRYPTION_DECRYPTED) {
                     file.delete();
                 }
+                disconnectSocks5Connections();
             }
             Log.d(Config.LOGTAG, "successfully transmitted file:" + file.getAbsolutePath() + " (" + CryptoHelper.bytesToHex(file.getSha1Sum()) + ")");
             if (message.getEncryption() != Message.ENCRYPTION_PGP) {


### PR DESCRIPTION
Sometimes even in Conversations-to-Conversations I see symptoms like receiver
says 99% done, sender says 100% done, hangs like that and then file transfer
fails.

I was having this issue fairly reliably between my emulator and my test device.
Adding this close caused the transfer to succeed 100% of the time.  I'm not sure
why the receiver didn't read all the data properly without the close, but this
fixes it.