### PR TITLE
A Quicky user can be a stranger

### DIFF
--- a/src/main/java/eu/siacs/conversations/entities/Conversation.java
+++ b/src/main/java/eu/siacs/conversations/entities/Conversation.java
@@ -1076,7 +1076,7 @@ public class Conversation extends AbstractEntity implements Blockable, Comparabl
                 && !contact.isOwnServer()
                 && !contact.showInContactList()
                 && !contact.isSelf()
-                && !JidHelper.isQuicksyDomain(contact.getJid())
+                && !(contact.getJid().isDomainJid() && JidHelper.isQuicksyDomain(contact.getJid()))
                 && sentMessagesCount() == 0;
     }
 


### PR DESCRIPTION
At some point a refactor changed this check from checking that the quicksy
domain itself is talking to you, to checking that anyone using quicksy is
talking to you, which breaks the notifications from strangers setting for
quicksy users.