### PR TITLE
Show the name of the sender in search results

### DIFF
--- a/src/main/java/eu/siacs/conversations/ui/SearchActivity.java
+++ b/src/main/java/eu/siacs/conversations/ui/SearchActivity.java
@@ -97,7 +97,7 @@ public class SearchActivity extends XmppActivity implements TextWatcher, OnSearc
 		this.binding = DataBindingUtil.setContentView(this, R.layout.activity_search);
 		setSupportActionBar(this.binding.toolbar);
 		configureActionBar(getSupportActionBar());
-		this.messageListAdapter = new MessageAdapter(this, this.messages);
+		this.messageListAdapter = new MessageAdapter(this, this.messages, uuid == null);
 		this.messageListAdapter.setOnContactPictureClicked(this);
 		this.binding.searchResults.setAdapter(messageListAdapter);
 		registerForContextMenu(this.binding.searchResults);

--- a/src/main/java/eu/siacs/conversations/ui/adapter/MessageAdapter.java
+++ b/src/main/java/eu/siacs/conversations/ui/adapter/MessageAdapter.java
@@ -87,6 +87,7 @@ public class MessageAdapter extends ArrayAdapter<Message> {
     private OnContactPictureClicked mOnContactPictureClickedListener;
     private OnContactPictureLongClicked mOnContactPictureLongClickedListener;
     private boolean mUseGreenBackground = false;
+    private boolean mForceNames = false;
 
     public MessageAdapter(XmppActivity activity, List<Message> messages) {
         super(activity, 0, messages);
@@ -96,6 +97,10 @@ public class MessageAdapter extends ArrayAdapter<Message> {
         updatePreferences();
     }
 
+    public MessageAdapter(XmppActivity activity, List<Message> messages, boolean forceNames) {
+        this(activity, messages);
+        mForceNames = forceNames;
+    }
 
     private static void resetClickListener(View... views) {
         for (View view : views) {
@@ -233,7 +238,7 @@ public class MessageAdapter extends ArrayAdapter<Message> {
                 error = true;
                 break;
             default:
-                if (multiReceived) {
+                if (mForceNames || multiReceived) {
                     info = UIHelper.getMessageDisplayName(message);
                 }
                 break;


### PR DESCRIPTION
Just like a MUC, search results lack the context to be sure who sent a message, so show the name in the result item.