### PR TITLE
accept and reject are both things that can come from other resources

### DIFF
--- a/src/main/java/eu/siacs/conversations/xmpp/jingle/JingleConnectionManager.java
+++ b/src/main/java/eu/siacs/conversations/xmpp/jingle/JingleConnectionManager.java
@@ -252,7 +252,7 @@ public class JingleConnectionManager extends AbstractConnectionManager {
         if (sessionId == null) {
             return;
         }
-        if ("accept".equals(message.getName())) {
+        if ("accept".equals(message.getName()) || "reject".equals(message.getName())) {
             for (AbstractJingleConnection connection : connections.values()) {
                 if (connection instanceof JingleRtpConnection) {
                     final JingleRtpConnection rtpConnection = (JingleRtpConnection) connection;


### PR DESCRIPTION
So if someone else sends one to the bare JID, we should deliver it to any connection that matches.

Without this, a reject in Movim will be ignored by Conversations.