### PR TITLE
Don't ignore empty bodies

### DIFF
--- a/src/main/java/eu/siacs/conversations/xml/LocalizedContent.java
+++ b/src/main/java/eu/siacs/conversations/xml/LocalizedContent.java
@@ -29,8 +29,8 @@ public class LocalizedContent {
                 final String childLanguage = child.getAttribute("xml:lang");
                 final String lang = childLanguage == null ? parentLanguage : childLanguage;
                 final String content = child.getContent();
-                if (content != null && (namespace == null || "jabber:client".equals(namespace))) {
-                    if (contents.put(lang, content) != null) {
+                if (namespace == null || "jabber:client".equals(namespace)) {
+                    if (contents.put(lang, content == null ? "" : content) != null) {
                         //anything that has multiple contents for the same language is invalid
                         return null;
                     }


### PR DESCRIPTION
A body that is present but has an empty string is not the same as no body.  It may be useful for example for a message correction to an empty string.