### PR TITLE
Quotee's name will now be added to the quote.

### DIFF
--- a/src/main/java/eu/siacs/conversations/utils/MessageUtils.java
+++ b/src/main/java/eu/siacs/conversations/utils/MessageUtils.java
@@ -50,6 +50,7 @@ public class MessageUtils {
     public static String prepareQuote(Message message) {
         final StringBuilder builder = new StringBuilder();
         final String body;
+        final String quotee = UIHelper.getMessageDisplayName(message);
         if (message.hasMeCommand()) {
             final String nick;
             if (message.getStatus() == Message.STATUS_RECEIVED) {
@@ -61,9 +62,9 @@ public class MessageUtils {
             } else {
                 nick = UIHelper.getMessageDisplayName(message);
             }
-            body = nick + " " + message.getBody().substring(Message.ME_COMMAND.length());
+            body = "*" + nick + " " + message.getBody().substring(Message.ME_COMMAND.length()) +"*";
         } else {
-            body = message.getMergedBody().toString();
+            body = quotee + " wrote:\n" + message.getMergedBody().toString();
         }
         for (String line : body.split("\n")) {
             if (!(line.length() <= 0) && QuoteHelper.isNestedTooDeeply(line)) {


### PR DESCRIPTION
Quotee's name will be appended to the message when quoted. Changes:
 Line 53 - variable that holds quotee's name
 Line 67 - variable quotee is appended to the beginning of the body string, then a string " wrote:\n" is added for a nice visual effect.

 Line 65 - Because of the change, if someone uses /me then the quote looks "simple". 
  To me, a /me is like reaction. (/me pukes, /me smiles) - it should be "distinguished" from other quotes, thus I made the whole "/me" quote bald to "pop up"

-----------------
Hello. 
I am aware of the following pull request:
https://github.com/iNPUTmice/Conversations/pull/4091

But in my case, I'm modifying "MessageUtils.java" to easily add the name from Message object.
The change is very simple.
In function prepareQuote() I used UIHelper.getMessageDisplayName() in order to assign the name to a variable.
Then, I simply appended the variable to the general quote body.

Because of this, I also modified how /me quotes are handled.
Basically, I made them bold to "stand out". 
If name-appending is a good pull request but /me "bolding" is not, then I can make a new pull request without the /me change.

------------

This is bare bones. No toggle.
I've seen that [SmsS4](https://github.com/SmsS4) created a nice toggle in the menu.
I can add that too if needed.

I just think, such name "appending" should be a default.
I was getting tired of manually adding the names, because I mostly talk in MUCs.


-----
On a second thought, perhaps I should have used message.getAvatarName()
because UIHelper.getMessageDisplayName() is a return of .getAvatarName()

This can be fixed if needed.

-------------
Screenshot:

![example](https://user-images.githubusercontent.com/48770967/199803697-3e718761-8c19-42ae-aeeb-7ab88eb31d98.jpg)
